### PR TITLE
修复3个关于文件上传的bug

### DIFF
--- a/app/controllers/comment.php
+++ b/app/controllers/comment.php
@@ -186,7 +186,11 @@ class Comment extends SB_Controller
 					exit;
 				}	
 			}
+			
 			$data['title'] = '编辑回贴';
+			//开启storage config
+			$this->load->config('qiniu');
+		
 	        $data['csrf_name'] = $this->security->get_csrf_token_name();
 	        $data['csrf_token'] = $this->security->get_csrf_hash();
 			$this->load->view('comment_edit',$data);

--- a/themes/default/comment_edit.php
+++ b/themes/default/comment_edit.php
@@ -28,7 +28,7 @@
                     </div>
                     <div class="panel-body">
 						<form accept-charset="UTF-8" action="<?php echo site_url('comment/edit/'.$comment['node_id'].'/'.$comment['topic_id'].'/'.$comment['id'])?>" id="new_topic" method="post" novalidate="novalidate" name="add_new">
-						<input type="hidden" name="<?php echo $csrf_name;?>" value="<?php echo $csrf_token;?>">
+						<input type="hidden" name="<?php echo $csrf_name;?>" value="<?php echo $csrf_token;?>" id="token">
 						<input name="uid" type="hidden" value="1" />
 						<input name="node_id" type="hidden" value="1" />
 						<div class="form-group">

--- a/themes/default/topic_edit.php
+++ b/themes/default/topic_edit.php
@@ -25,7 +25,7 @@
                     </div>
                     <div class="panel-body">
 <form accept-charset="UTF-8" action="<?php echo site_url('/topic/edit/'.$item['topic_id']);?>" class="simple_form form-vertical" id="new_topic" method="post">
-<input type="hidden" name="<?php echo $csrf_name;?>" value="<?php echo $csrf_token;?>">
+<input type="hidden" name="<?php echo $csrf_name;?>" value="<?php echo $csrf_token;?>" id="token">
 <input name="uid" type="hidden" value="1" />
 <input name="node_id" type="hidden" value="1" />
 <div class="form-group">


### PR DESCRIPTION
1.修复csrf token 不随json post提交，导致500错误的问题。
原因：js通过#token获取token，这2个文件中没有设置好id="token"。
2. 修复comment/edit载入错误js文件的问题。
原因：controller中没载入config配置，导致错误。 
